### PR TITLE
Add a link to the developer day in the schedule

### DIFF
--- a/docs/schedule.md
+++ b/docs/schedule.md
@@ -58,10 +58,11 @@ Twitter: [#bioc2019][tweet]<br />
 
 
 ## Schedule (Tentative)
-* Day 0: Monday June 24 (developer day).
+* [Day 0][0]: Monday June 24 (developer day).
 * [Day 1](#day-1-tuesday-june-25): Tuesday June 25.
 * [Day 2](#day-2-wednesday-june-26): Wednesday June 26.
 
+[0]: https://bioc2019.bioconductor.org/schedule-developer-day
 [1]: http://sites.utoronto.ca/andrewslab/
 [2]: https://www.pmgenomics.ca/bhklab/
 [3]: https://www.rits.onc.jhmi.edu/DBB/members/?members=Faculty&member=efertig1


### PR DESCRIPTION
I added a link in Day 0 to the developer page.

I kept forgetting that the developer day schedule is not on the schedule page. I hope this way might be easier for other users