### PR TITLE
Add NYU Langone travel info.

### DIFF
--- a/docs/posters.md
+++ b/docs/posters.md
@@ -13,4 +13,86 @@ Twitter: [#bioc2019][tweet]
 
 ## Posters
 
-To be added.
+Robert A. Amezquita\*, Vince J. Carey, Lindsay N. Carpp, Ludwig Geistlinger, Aaron T. L.Lun, Federico Marini, Kevin Rue-Albrecht, Davide Risso, Charlotte Soneson, Levi Waldron, Mike Smith, Wolfgang Huber, Hervé Pagès, Martin Morgan, Raphael Gottardo, and Stephanie C. Hicks. Orchestrating Single-Cell Analysis with Bioconductor. Keywords: scRNAseq, singlecell, genomics, review.
+
+Farias Amorim C\*, Berry A, Beiting DP. Title TBD. Keywords: Parasite, Host, RNAseq, Transcriptomics, Infectious Diseases.
+
+Sonali Arora\*, Siobhan Pattwell, Eric Holland, Hamid Bolouri. Gene specific variability between commonly used RNA-seq pipelines. Keywords: TCGA, GTEx, rna-seq, big-data, genomics.
+
+Avshalumov A\*, Rahman M\*, Wultsch C, and Krampis K. MicrobiomeExplorer: An interactive and web-based R Shiny analysis platform for microbiome research. Keywords: Microbiome, Metagenomics, Clustering, Visualization, Software.
+
+Barrows D\*, Allis CD, Carroll T. Visualization and annotation of read signal over genomic ranges with profileplyr. Keywords: ChIPSeq, ChipOnChip, Coverage, DataImport, Sequencing.
+
+Belleau P\*, Deschenes A\*, Adelaja A, Medina S, Ranade N, and Dillman A. HLAClusteRView: HLA typing clustering and visualization based on specific similarity metrics. Keywords: Visualization, Software, ImmunoOncology, Clustering, BiologicalQuestion.
+
+Dror Berel\*. Bioc2mlr: Utility functions to transform Bioconductor's S4 omic classes into mlr's task and CPOs. Keywords: SummarizedExperiment, MultiAssayExperiment, mlr, machine-learning, mlrCPO.
+
+Brehm Z\*, Halushka M and McCall M. Deconvolutional mixture modeling to account for cell-type composition in tissue samples. Keywords: RNASeq, GeneExpression.
+
+Burton D\*, McCall MN. Likelihood Based Mixture Modeling in Gene Regulatory Network Inference. Keywords: NetworkInference, SystemsBiology, GeneRegulation, GeneExpression, CancerData.
+
+Carey VJ\*, Stubbs BJ, Gopaulakrishnan S, Pollack S, Davis S. Bioconductor at cloud scale. Keywords: Software, GenomicVariation, CloudComputing, ImmunoOncology.
+
+Eric Bouillet, Christine Choirat\*, Rok Roskar, Chandrasekhar Ramakrishnan, Olivier Verscheure, and the RENKU development team. Reproducible workflows and Bionconductor package development with the RENKU platform. Keywords: Reproducibility, Common Workflow Language, Continuous Integration, Docker.
+
+Antonio Colaprico\*, Catharina Olsen, Claudia Cava, Thilde Terkelsen, Matthew H. Bailey, Tiago C. Silva, André Vidas Olsen, Laura Cantini, Andrei Zinovyev, Emmanuel Barillot, Gloria Bertoli, Isabella Castiglioni, Houtan Noushmehr, Gabriel J. Odom, Xi Chen, Gianluca Bontempi, Elena Papaleo. Title TBD. Keywords: DNAMethylation, GeneExpression, Pathways, Sequencing, Software.
+
+Dragich J\*. A BioC workflow to go from high-throughput genetic data back to detailed, personalized genetic insights. Keywords: Genetic, variant, human, haploinsufficient, protein.
+
+Jessica R. Holmes, Jenny Drnevich\*, Lois L. Hoyer, Christopher J. Fields. Broadening the impact of bioinformatics  in research and education. Keywords: RNASeq.
+
+Hejazi, NS\*, van der Laan MJ, Hubbard AE. Generalized Variance Moderation for Locally Efficient Estimation in High-Dimensional Biology. Keywords: GeneExpression, DifferentialExpression, Microarray,  RNASeq, MultipleComparison.
+
+Huang D\*, Coban EB, Wultsch C, Liu J, Casaccia P, Krampis K. Noise filtering, exploratory data analysis and trajectory inference from single-cell (scSeq) genomic sequencing using the R / Bioconductor software libraries. Keywords: SingleCellWorkflow, SingleCell, Transcriptomics, Visualization, BiomedicalInformatics.
+
+Nahed Jalloul\*, Greg Reidlinger, Shridar Ganesan, Hossein Khiabanian. Title TBD. Keywords: targeted sequencing panels, bioinformatics analysis, clinical implementation.
+
+Lawson J\*, Smith J, Garrett-Bakelman F, Bekiranov S, and Sheffield N. Coordinate Covariation Analysis (COCOA): Understanding Interindividual Variation in Data with Genomic Coordinates. Keywords: Epigenetics, GenomeAnnotation, GenomicVariation, PrincipalComponent.
+
+Loh JW\*, Guccione C, Di Clemente F, Riedlinger G, Ganesan S, and Khiabanian H. All-FIT: Allele-Frequency-based Imputation of Tumor Purity from High-Depth Sequencing Data. Keywords: clinical sequencing, specimen purity estimation, tumor-only sequencing.
+
+Martin, T.C.\*, Bell, J.T. coMET: visualization of regional epigenome-wide association scan results and DNA co-methylation patterns. Keywords: Visualization, ChIPSeq, DNAMethylation, GenomeWideAssociation, MethylSeq.
+
+Gu Y, McDavid A\*. CellaRepertorium Facilitates scRNAseq Immune Repertoire Analysis. Keywords: SingleCell, ImmunoOncology, Sequencing, QualityControl, MultipleComparison.
+
+Eliatan Niktab\*, Dinindu S Senanayake, Andrew B Munkacsi, Paul H Atkinson, Kelly V. Ruggles, Mark Walterfang. Title TBD. Keywords: GraphAndNetwork, GenomeWideAssociation, AnnotationData, SNPData.
+
+Odom G\*, Ban Y\*, Liu L, Wang L, Chen X. Integrative pathway analysis with modern PCA methodology and gene selection. Keywords: Pathways, GeneSetEnrichment, DimensionReduction, FeatureExtraction, PrincipalComponent.
+
+Hatice U. Osmanbeyoglu\*, Fumiko Shimizu, Angela Rynne-Vidal, Direna Alonso-Curbelo, Hsuan-An Chen, Hannah Y. Wen, Tsz-Lun Yeung, Petar Jelinic, Pedram Razavi, Scott W. Lowe, Samuel C. Mok, Gabriela Chiosis, Douglas A. Levine, Christina S. Leslie. Title TBD. Keywords: software.
+
+Jianhong Ou\*, Julie Zhu. TrackViewer: Lollipop/dandelion plots for methylation status and mutation data. Keywords: Software, Visualization, VariantAnnotation.
+
+Ward C, To TH, Pederson S\*. ngsReports and strandCheckR: Two QC packages for bolting directly into NGS pipelines. Keywords: QualityControl, ReportWriting.
+
+Ploenzke MS\*, Irizarry RI. Shallow convolutional methods for learning genomic sequence motifs. Keywords: convolution neural network motif interpretable.
+
+Anna Quaglieri\*, Christoffer Flensburg. Varikondo: spark joy in your variants!. Keywords: DataImport, Sequencing, GeneticVariants, Tidy, Standardise.
+
+Lluís Revilla Sancho\*, Pau Sancho-Bru, Juan José Salvatella Lozano. BioCor: a package to measure functional similarities. Keywords: Pathways, StatisticalMethod, SystemsBiology, Similarity, Clustering.
+
+Sanjeev Sariya\* and Giuseppe Tosto. Epistasis analysis for Late-Onset of Alzheimer’s disease (LOAD) using Exome-Chip data. Keywords: Epistasis, interaction, exome.
+
+Hirak Sarkar\*, Avi Srivastava and Rob Patro. Minnow: A principled framework for rapid simulation of dscRNA-seq data at the read level. Keywords: scRNA-seq, simulation, multi mapping.
+
+Singh A\*, Bhanot G, Khiabanian H. TuBA: Tunable Biclustering Algorithm for uncovering altered transcriptional profiles in large gene expression datasets of tumors. Keywords: Transcriptomics, biclustering, gene co-expression, tumor heterogeneity.
+
+Singh R\*, Ramzan T\*, Avshalumov A, Rahman M, Wultsch C, Krampis K. Human microbiome and minority health: unravelling variations associated with disease and ethnicity. Keywords: Microbiome, MultipleComparison, Metagenomics, BiomedicalInformatics.
+
+Soneson C\*, Yao Y, Bratus-Neuenschwander A, Patrignani A, Robinson MD, Hussain S. On the characterisation of complex transcriptomes with Nanopore native RNA sequencing. Keywords: GenomeAnnotation, Transcriptomics, Sequencing.
+
+Srivastava A\*, Malik L, Smith T, Sudbery I, Patro R. Alevin efficiently estimates accurate gene abundances from dscRNA-seq data. Keywords: dscRNA-seq, Quantification, UMI-Deduplication, salmon, alevin.
+
+Elitsa Stoyanova\*, Eric Schmidt, Thomas Carroll, Nathaniel Heintz. TRAPR AND TRAPR.DB: A SOFTWARE PACKAGE FOR THE CURATION, ASSESSMENT AND VISUALIZATION OF TRAP-SEQ DATA. Keywords: RNASeq, GeneExpression.
+
+Tang M\*, Kaymaz Y, Eichhorn S, Liang Z,  Dulac C, Sackton T. Scclusteval: An R package for evaluating single cell RNAseq clustering. Keywords: GeneExpression Transcriptomics Clustering SingleCell.
+
+A. B. Villaseñor-Altamirano\*, Y. I. Balderas-Martínez, M. Moretto, A. Zayas-Del Moral, M. Maldonado, A. Munguía-Reyes, J. S. García-Sotelo, L. A. Aguilar Bautista, K. Engelen, M. Selman, A. Medina-Rivera, J. Collado-Vides. Title TBD. Keywords: None Given.
+
+Vaestermark AJ, Walters JR\*. Title TBD. Keywords: DataRepresentation, Sequencing, GeneExpression, SystemsBiology, DifferentialExpression.
+
+
+
+
+
+

--- a/docs/travel-accommodations.md
+++ b/docs/travel-accommodations.md
@@ -52,9 +52,28 @@ Closer to NYU:
 * [The Roger Smith Hotel](https://groups.hotels.com/Hotel/HotelRoomTypes.htm?hotelID=179766&inDate=06/23/19&outDate=06/27/19&NumRooms=1&gp=78.00&gid=4975917#HotelName) (starting at $211+tax)
 
 ## NYU Langone 
-<!-- The information below for getting to Rockefeller was suggested by
-Jennifer Einstein at Rockefeller's public relations department.  Local
-organizers, feel free to edit. -->
+Please arrive at NYU through the main entrance on 1st Avenue between 30th and 34th street.
+<iframe src="https://goo.gl/maps/63RC6jh1zgJ2" width="400" height="350" frameborder="0" style="border:0" allowfullscreen></iframe>
+
+### Local Transportation to NYU
+
+**Buses**: The M15 local bus runs the length of First Avenue in Manhattan and stops near the front of the NYU Langone Medical Center. For the M15 limited bus, which runs express, the closest stop is at 29th Street. The M34 bus runs the length of 34th Street in Manhattan and stops directly in front of the north entrance to NYU Medical Center on 34th Street at First Avenue. The M16 bus, which connects with nationwide bus service at the Port Authority Bus Terminal (42nd Street and Eighth Avenue), has a nearby stop at First Avenue and 23rd Street. One bus fare is $2.50. A MetroCard or coins are required.
+
+**Subway**: The subway costs $2.75. The stops closest to the NYU Langone Medical Center and the Bellevue Hospital Center are:
+33rd Street or 28th Street stops (at Park Avenue) on the Number 6 line.
+Grand Central Terminal at 42nd Street between Lexington Avenue and Park Avenue (4, 5, 6).
+
+**Available Parking Options**: https://nyulangone.org/locations/tisch-hospital/parking
+
+### Getting around NYU Langone:  
+
+**Farkas Auditorium**: Follow the Yellow Pathway and you will quickly come upon the Alumni Hall. The Farkas Auditorium will be to your right. If you have reached the Medical Science Building then you have gone too far. Registration will take place here. 
+Smilow Research Center—Found at the very end of the Yellow Pathway.  Upon entering the Medical Center, take the Yellow Pathway to the Smilow elevator bank at the back of the building. 
+
+**Medical Science Building (MSB)**: Found midway along the Yellow Pathway.  The MSB conference room for the workshop can be found down by continuing past the elevators into the Smilow Research Building and continuing down the stairs (or taking the elevator 1 floor down).
+
+**Science Building (SB)**: The main entrance of this building is located on E. 30th Street and has access points from the Smilow Research Center and the Medical Science Building.  From MSB, please take the elevators to the ground floor and follow the signs marked “Science Building.”  This building can also be access by a bridge next to the Smilow Seminar Room.
+
 
 ## Rockefeller University
 


### PR DESCRIPTION
This pull request adds the NYU Langone travel info to the travel-accommodations page and the presenter, authors, title, and keywords for the posters. 